### PR TITLE
fix: allow optional blog pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ const generator = async (blog) => {
   }
 
   const pagesWithContent = [];
-  for (const page of blog.pages) {
+  for (const page of blog.pages || []) {
     let content = "asd";
     try {
       content = await fetchFile(page.source);


### PR DESCRIPTION
The generator will fail when the `pages` value is missing from the `blog.json` file.
This change allows the `page` value to be optional in the `blog.json` file.

Discovered as `pages` is missing from https://github.com/jsonblog/jsonblog-schema/blob/master/sample.blog.json

This lib is a dependency of `jsonblog-cli`. Example error when `pages` key is missing:

```
(node:29953) UnhandledPromiseRejectionWarning: TypeError: blog.pages is not iterable
    at generator (/Users/tod/.nvm/versions/node/v14.17.6/lib/node_modules/jsonblog-cli/node_modules/jsonblog-generator-boilerplate/index.js:100:27)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async /Users/tod/.nvm/versions/node/v14.17.6/lib/node_modules/jsonblog-cli/index.js:26:21
```